### PR TITLE
Custom WMV Support

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,8 @@
 Changelog
+0.9.2.0
+SnakeBite/MakeBite:
+Added custom WMV support.
+
 0.9.1.9
 SnakeBite/MakeBite:
 Gameversion update to 1.0.15.3

--- a/SnakeBite/Classes/InstallManager.cs
+++ b/SnakeBite/Classes/InstallManager.cs
@@ -140,6 +140,7 @@ namespace SnakeBite
             FastZip unzipper = new FastZip();
             GameData gameData = manager.GetGameData();
 
+            bool isAddingWMV = false; //ZIP: WMV Support
             foreach (string modFilePath in modFilePaths) 
             {
                 Debug.LogLine($"[Install] Installation started: {Path.GetFileName(modFilePath)}", Debug.LogLevel.Basic);
@@ -183,9 +184,18 @@ namespace SnakeBite
                 Debug.LogLine("[Install] Copying game dir files", Debug.LogLevel.Basic);
                 InstallGameDirFiles(extractedModEntry, ref gameData);
 
+                //ZIP: WMV Support
+                if (!isAddingWMV)
+                {
+                    if (extractedModEntry.ModWmvEntries.Count > 0)
+                        isAddingWMV = true;
+                }
             }
 
             manager.SetGameData(gameData);
+
+            //ZIP: Are we installing any mods containing custom WMVs? If so, update.
+            if (isAddingWMV) ModManager.UpdateFoxfs(manager.GetInstalledMods());
         }
 
         private static void ValidateModEntries(ref ModEntry modEntry)

--- a/SnakeBite/Classes/SettingsManager.cs
+++ b/SnakeBite/Classes/SettingsManager.cs
@@ -443,6 +443,9 @@ namespace SnakeBite
         [XmlArray("FileEntries")]
         public List<ModFileEntry> ModFileEntries { get; set; } = new List<ModFileEntry>();
 
+        [XmlArray("WmvEntries")]
+        public List<ModWmvEntry> ModWmvEntries { get; set; } = new List<ModWmvEntry>();
+
         public void ReadFromFile(string Filename)
         {
             // Read mod metadata from xml
@@ -466,6 +469,7 @@ namespace SnakeBite
             ModQarEntries = loaded.ModQarEntries;
             ModFpkEntries = loaded.ModFpkEntries;
             ModFileEntries = loaded.ModFileEntries;
+            ModWmvEntries = loaded.ModWmvEntries;
 
             s.Close();
         }
@@ -541,5 +545,12 @@ namespace SnakeBite
 
         [XmlAttribute("ContentHash")]
         public string ContentHash { get; set; }
+    }
+
+    [XmlType("WmvEntry")]
+    public class ModWmvEntry
+    {
+        [XmlAttribute("Hash")]
+        public ulong Hash { get; set; }
     }
 }

--- a/SnakeBite/Classes/UninstallManager.cs
+++ b/SnakeBite/Classes/UninstallManager.cs
@@ -153,6 +153,7 @@ namespace SnakeBite
             Debug.LogLine("[Uninstall] Removing any unmodified fpk entries", Debug.LogLevel.Basic);
             RemoveDemoddedQars(ref zeroFiles, fullRemoveQarPaths);
 
+            bool isRemovingWMV = false; //ZIP: WMV Support
             GameData gameData = SBBuildManager.GetGameData();
             foreach (ModEntry uninstallMod in uninstallMods)
             {
@@ -163,8 +164,19 @@ namespace SnakeBite
 
                 Debug.LogLine(String.Format("[Uninstall] Removing any loose textures for {0}", uninstallMod.Name), Debug.LogLevel.Basic);
                 UninstallLooseFtexs(uninstallMod, ref oneFilesList, ref gameData);
+
+                //ZIP: WMV Support
+                if (!isRemovingWMV)
+                {
+                    if (uninstallMod.ModWmvEntries.Count > 0)
+                        isRemovingWMV = true;
+                }
             }
+
             SBBuildManager.SetGameData(gameData);
+
+            //ZIP: Are we removing any mods containing custom WMVs? If so, update.
+            if (isRemovingWMV)ModManager.UpdateFoxfs(SBBuildManager.GetInstalledMods());
         }
 
         private static void GetFpkRemovalLists(List<ModEntry> uninstallMods, out List<string> fullRemoveQarPaths, out List<ModQarEntry> partialEditQarEntries, out List<ModFpkEntry> partialEditFpkEntries)

--- a/SnakeBite/Properties/AssemblyInfo.cs
+++ b/SnakeBite/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("0.9.1.9")]
+[assembly: AssemblyVersion("0.9.2.0")]

--- a/makebite/Classes/MakeBite.cs
+++ b/makebite/Classes/MakeBite.cs
@@ -303,20 +303,32 @@ namespace makebite
             }
 
             metaData.ModQarEntries = new List<ModQarEntry>();
+            metaData.ModWmvEntries = new List<ModWmvEntry>(); //ZIP: Custom WMV Support
             foreach (string qarFile in qarFiles)
             {
                 string subDir = qarFile.Substring(0, qarFile.LastIndexOf("\\")).Substring(SourceDir.Length).TrimStart('\\'); // the subdirectory for XML output
                 string qarFilePath = Tools.ToQarPath(qarFile.Substring(SourceDir.Length));
-                
-                if (!Directory.Exists(Path.Combine("_build", subDir))) Directory.CreateDirectory(Path.Combine("_build", subDir)); // create file structure
-                File.Copy(qarFile, Path.Combine("_build", Tools.ToWinPath(qarFilePath)), true);
+ 
+                if (!qarFilePath.Contains("/Assets/tpp/movie/Win/"))
+                {
+                    if (!Directory.Exists(Path.Combine("_build", subDir))) Directory.CreateDirectory(Path.Combine("_build", subDir)); // create file structure
+                    File.Copy(qarFile, Path.Combine("_build", Tools.ToWinPath(qarFilePath)), true);
 
-                ulong hash = Tools.NameToHash(qarFilePath);
-                metaData.ModQarEntries.Add(new ModQarEntry() {
-                    FilePath = qarFilePath,
-                    Compressed = qarFile.EndsWith(".fpk") || qarFile.EndsWith(".fpkd") ? true : false,
-                    ContentHash = Tools.GetMd5Hash(qarFile), Hash = hash
-                });
+                    ulong hash = Tools.NameToHash(qarFilePath);
+                    metaData.ModQarEntries.Add(new ModQarEntry()
+                    {
+                        FilePath = qarFilePath,
+                        Compressed = qarFile.EndsWith(".fpk") || qarFile.EndsWith(".fpkd") ? true : false,
+                        ContentHash = Tools.GetMd5Hash(qarFile),
+                        Hash = hash
+                    });            
+                }
+                else //ZIP: If any .dat files are found in "/Assets/tpp/movie/Win/", add them to WmvEntries. But don't add them to QarEntries.
+                {
+                    //TODO: Get HashFileNameWithExtension to work with strings containing ".wmv"
+                    ulong datToWMV = 3924887075253387264; //ZIP: .wmv extension doesn't hash properly. Hack.
+                    metaData.ModWmvEntries.Add(new ModWmvEntry() { Hash = Tools.NameToHash(qarFilePath) + datToWMV });
+                }
             }
 
             //tex build external entries

--- a/makebite/Classes/XmlSettings.cs
+++ b/makebite/Classes/XmlSettings.cs
@@ -66,6 +66,9 @@ namespace SnakeBite
         [XmlArray("FileEntries")]
         public List<ModFileEntry> ModFileEntries { get; set; } = new List<ModFileEntry>();
 
+        [XmlArray("WmvEntries")]
+        public List<ModWmvEntry> ModWmvEntries { get; set; } = new List<ModWmvEntry>();
+
         public void ReadFromFile(string Filename)
         {
             // Read mod metadata from xml
@@ -106,6 +109,7 @@ namespace SnakeBite
             ModQarEntries = loaded.ModQarEntries;
             ModFpkEntries = loaded.ModFpkEntries;
             ModFileEntries = loaded.ModFileEntries;
+            ModWmvEntries = loaded.ModWmvEntries;
 
             s.Close();
         }
@@ -159,5 +163,12 @@ namespace SnakeBite
 
         [XmlAttribute("ContentHash")]
         public string ContentHash { get; set; }
+    }
+
+    [XmlType("WmvEntry")]
+    public class ModWmvEntry
+    {
+        [XmlAttribute("Hash")]
+        public ulong Hash { get; set; }
     }
 }

--- a/makebite/Properties/AssemblyInfo.cs
+++ b/makebite/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.1.9")]
-[assembly: AssemblyFileVersion("0.9.1.9")]
+[assembly: AssemblyVersion("0.9.2.0")]
+[assembly: AssemblyFileVersion("0.9.2.0")]


### PR DESCRIPTION
### Description
Adds WMV support to MakeBite/SnakeBite. If MakeBite finds any **.dat** files in **"/Assets/tpp/movie/Win/"**, it adds their hash as a decimal to **WmvEntries** in the mod's **metadata.xml**. **WmvEntries** can be manually added too. When Snakebite installs/uninstalls mods that contain custom WMVs, it will extract **chunk0.dat** and repack it with an updated **foxfs.dat** from **chunk0.dat.original**.

### Media
Here's a screenshot of 
- An example mod's metadata.xml
- Snakebite's output when installing/uninstalling the mod
- The extracted **foxfs.dat** from **chunk0.dat** after installing. 

![wmvsupport2](https://user-images.githubusercontent.com/92134852/166427267-10a1acca-c836-4673-9310-fdfae3e7e1fe.png)

### Authoring custom WMVs
- [**First, follow this guide on WMVs in MGSV.**](https://metalgearmodding.fandom.com/wiki/WMV)
- You can use [**QuickHash**](https://github.com/BobDoleOwndU/QuickHash) to generate the wmv's hashed file name. _**Use PathCode64 With Extension!**_
**Example: /Assets/tpp/movie/Win/your_video_name_here_en.wmv** generates the file name **e2fa9738df375511**
- Videos must be encoded in **WMV**, saved as **.dat** files in **Steam\steamapps\common\MGS_TPP\master**.

### Adding WmvEntries
To automatically generate **WmvEntries**, you can create an empty **.txt** file with your video's name, change the extension to **.dat**, and place it in **"/Assets/tpp/movie/Win/"**. This will add its hash as a decimal to the mod's **WmvEntries** list. 
![autogen](https://user-images.githubusercontent.com/92134852/166200228-98e8a411-4502-4677-aa3b-a9e8f8dbe72d.png)
You can also manually add them in the mod's **metadata.xml**:
```
<WmvEntries>
<WmvEntry Hash="*hashed decimal file path of wmv here*" />
</WmvEntries>
```